### PR TITLE
Add `GatOperator` trait and a new tumbling operator design

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ parallel = ["rayon", "std"]
 async = ["futures", "pin-project-lite"]
 tower = ["std", "async", "tower-service"]
 
+gat = []
+
 [dependencies.arrayvec]
 version = "0.7"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,17 @@ parallel = ["rayon", "std"]
 async = ["futures", "pin-project-lite"]
 tower = ["std", "async", "tower-service"]
 
-gat = []
+gat = ["tinyvec"]
 
 [dependencies.arrayvec]
 version = "0.7"
 optional = true
 default-features = false
+
+[dependencies.tinyvec]
+ version = "1.6.0"
+ features = ["alloc", "rustc_1_55"]
+ optional = true
 
 [dependencies.time]
 version = "0.3"

--- a/examples/gat.rs
+++ b/examples/gat.rs
@@ -5,7 +5,7 @@ struct Collect {
     queue: Vec<usize>,
 }
 
-impl Operator<usize> for Collect {
+impl GatOperator<usize> for Collect {
     type Output<'out> = &'out [usize];
 
     fn next<'out>(&'out mut self, input: usize) -> Self::Output<'out>
@@ -19,7 +19,7 @@ impl Operator<usize> for Collect {
 
 struct Mux;
 
-impl<'a> Operator<&'a [usize]> for Mux {
+impl<'a> GatOperator<&'a [usize]> for Mux {
     type Output<'out> = Option<usize> where 'a: 'out;
 
     fn next<'out>(&'out mut self, input: &'a [usize]) -> Self::Output<'out>

--- a/examples/gat.rs
+++ b/examples/gat.rs
@@ -1,13 +1,4 @@
-trait Operator<I> {
-    type Output<'out>
-    where
-        Self: 'out,
-        I: 'out;
-
-    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
-    where
-        I: 'out;
-}
+use indicator::gat::*;
 
 #[derive(Default)]
 struct Collect {
@@ -45,29 +36,8 @@ impl<'a> Operator<&'a [usize]> for Mux {
     }
 }
 
-pub struct Then<P1, P2>(P1, P2);
-
-impl<I, P1, P2> Operator<I> for Then<P1, P2>
-where
-    P1: Operator<I>,
-    P2: for<'out> Operator<P1::Output<'out>>,
-{
-    type Output<'out> = <P2 as Operator<<P1 as Operator<I>>::Output<'out>>>::Output<'out>
-    where
-        I: 'out,
-        P1: 'out,
-        P2: 'out;
-
-    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
-    where
-        I: 'out,
-    {
-        self.1.next(self.0.next(input))
-    }
-}
-
 fn main() {
-    let mut op = Then(Collect::default(), Mux);
+    let mut op = Collect::default().then(Mux);
     for x in [1, 2, 3, 4, 5] {
         println!("{:?}", op.next(x));
     }

--- a/examples/gat.rs
+++ b/examples/gat.rs
@@ -1,0 +1,74 @@
+trait Operator<I> {
+    type Output<'out>
+    where
+        Self: 'out,
+        I: 'out;
+
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out;
+}
+
+#[derive(Default)]
+struct Collect {
+    queue: Vec<usize>,
+}
+
+impl Operator<usize> for Collect {
+    type Output<'out> = &'out [usize];
+
+    fn next<'out>(&'out mut self, input: usize) -> Self::Output<'out>
+    where
+        usize: 'out,
+    {
+        self.queue.push(input);
+        &self.queue
+    }
+}
+
+struct Mux;
+
+impl<'a> Operator<&'a [usize]> for Mux {
+    type Output<'out> = Option<usize> where 'a: 'out;
+
+    fn next<'out>(&'out mut self, input: &'a [usize]) -> Self::Output<'out>
+    where
+        'a: 'out,
+    {
+        std::thread::scope(|s| {
+            let first = s.spawn(|| Some(input.first()? + 1));
+            let second = s.spawn(|| Some(input.get(1)? + 1));
+            let first = first.join().ok()??;
+            let second = second.join().ok()??;
+            Some(first + second)
+        })
+    }
+}
+
+pub struct Then<P1, P2>(P1, P2);
+
+impl<I, P1, P2> Operator<I> for Then<P1, P2>
+where
+    P1: Operator<I>,
+    P2: for<'out> Operator<P1::Output<'out>>,
+{
+    type Output<'out> = <P2 as Operator<<P1 as Operator<I>>::Output<'out>>>::Output<'out>
+    where
+        I: 'out,
+        P1: 'out,
+        P2: 'out;
+
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        self.1.next(self.0.next(input))
+    }
+}
+
+fn main() {
+    let mut op = Then(Collect::default(), Mux);
+    for x in [1, 2, 3, 4, 5] {
+        println!("{:?}", op.next(x));
+    }
+}

--- a/examples/sma.rs
+++ b/examples/sma.rs
@@ -1,0 +1,37 @@
+use indicator::{gat::*, Period, Tick, TickValue, TumblingWindow};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use time::{macros::datetime, UtcOffset};
+
+fn main() {
+    let period = Period::seconds(UtcOffset::UTC, 2);
+    let mut last_tick = Tick::BIG_BANG;
+    let cache = tumbling::<1, TickValue<_>, _, _>(3, move |w, x| {
+        if period.same_window(&last_tick, &x.tick) {
+            w.swap(x.value);
+        } else {
+            last_tick = x.tick;
+            w.push(x.value);
+        };
+    });
+
+    let mut sms = Decimal::ZERO;
+    let mut op = cache.map(|w| {
+        let outdated = w.change().outdated().copied().unwrap_or_default();
+        debug_assert!(w.len() != 0);
+        sms += w[0] - outdated;
+        let l = Decimal::new(w.len() as i64, 0);
+        sms / l
+    });
+
+    for x in [
+        TickValue::new(datetime!(2022-09-22 00:00:00 +00:00), dec!(1)),
+        TickValue::new(datetime!(2022-09-22 00:00:01 +00:00), dec!(2)),
+        TickValue::new(datetime!(2022-09-22 00:00:02 +00:00), dec!(3)),
+        TickValue::new(datetime!(2022-09-22 00:00:03 +00:00), dec!(4)),
+        TickValue::new(datetime!(2022-09-22 00:00:04 +00:00), dec!(5)),
+        TickValue::new(datetime!(2022-09-22 00:00:05 +00:00), dec!(6)),
+    ] {
+        println!("{}", op.next(x));
+    }
+}

--- a/examples/sma.rs
+++ b/examples/sma.rs
@@ -6,7 +6,6 @@ use time::{macros::datetime, UtcOffset};
 fn main() {
     let period = Period::seconds(UtcOffset::UTC, 2);
     let cache = cache::<3, TickValue<_>>(3, period);
-
     let mut sms = Decimal::ZERO;
     let mut op = cache.map(|w| {
         assert!(w.is_inline());

--- a/examples/sma.rs
+++ b/examples/sma.rs
@@ -1,4 +1,4 @@
-use indicator::{gat::*, Period, Tick, TickValue, TumblingWindow};
+use indicator::prelude::*;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use time::{macros::datetime, UtcOffset};

--- a/examples/then.rs
+++ b/examples/then.rs
@@ -1,0 +1,9 @@
+use indicator::*;
+
+fn main() {
+    let mut m = map(|x| x + 1);
+    let mut op = (&mut m).then(map(|x| x + 2));
+    for x in [1, 2, 3, 4, 5] {
+        println!("{:?}", op.next(x));
+    }
+}

--- a/examples/tsl.rs
+++ b/examples/tsl.rs
@@ -1,0 +1,63 @@
+use indicator::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use time::{macros::datetime, UtcOffset};
+
+fn tr(period: Period) -> impl Operator<TickValue<Decimal>, Output = TickValue<Decimal>> {
+    let close = cache::<2, TickValue<Decimal>>(2, period);
+    let high = {
+        let mut high = Decimal::ZERO;
+        view(move |w: QueueRef<TickValue<Decimal>>| {
+            if w.change().is_new_period() {
+                high = w[0].value;
+            } else {
+                high = w[0].value.max(high);
+            }
+            high
+        })
+    };
+    let low = {
+        let mut low = Decimal::ZERO;
+        view(move |w: QueueRef<TickValue<Decimal>>| {
+            if w.change().is_new_period() {
+                low = w[0].value;
+            } else {
+                low = w[0].value.min(low);
+            }
+            low
+        })
+    };
+    close
+        .then(
+            view(|w: QueueRef<TickValue<Decimal>>| {
+                let close1 = w.get(1).map(|t| t.value).unwrap_or_default();
+                w[0].tick.with_value(close1)
+            })
+            .mux_with(high)
+            .mux_with(low),
+        )
+        .map(|((close1, high), low)| {
+            close1.map(|close1| {
+                (high - low)
+                    .max((close1 - high).abs())
+                    .max((close1 - low).abs())
+            })
+        })
+        .into_operator()
+}
+
+fn main() {
+    let period = Period::seconds(UtcOffset::UTC, 2);
+    let mut op = tr(period);
+
+    for x in [
+        TickValue::new(datetime!(2022-09-22 00:00:00 +00:00), dec!(1)),
+        TickValue::new(datetime!(2022-09-22 00:00:01 +00:00), dec!(2)),
+        TickValue::new(datetime!(2022-09-22 00:00:02 +00:00), dec!(3)),
+        TickValue::new(datetime!(2022-09-22 00:00:03 +00:00), dec!(4)),
+        TickValue::new(datetime!(2022-09-22 00:00:04 +00:00), dec!(5)),
+        TickValue::new(datetime!(2022-09-22 00:00:05 +00:00), dec!(6)),
+    ] {
+        println!("{}", op.next(x));
+    }
+}

--- a/examples/tsl.rs
+++ b/examples/tsl.rs
@@ -3,8 +3,13 @@ use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use time::{macros::datetime, UtcOffset};
 
-fn tr(period: Period) -> impl Operator<TickValue<Decimal>, Output = TickValue<Decimal>> {
+fn tsl(
+    length: Decimal,
+    factor: Decimal,
+    period: Period,
+) -> impl Operator<TickValue<Decimal>, Output = TickValue<Decimal>> {
     let close = cache::<2, TickValue<Decimal>>(2, period);
+
     let high = {
         let mut high = Decimal::ZERO;
         view(move |w: QueueRef<TickValue<Decimal>>| {
@@ -16,6 +21,7 @@ fn tr(period: Period) -> impl Operator<TickValue<Decimal>, Output = TickValue<De
             high
         })
     };
+
     let low = {
         let mut low = Decimal::ZERO;
         view(move |w: QueueRef<TickValue<Decimal>>| {
@@ -27,36 +33,118 @@ fn tr(period: Period) -> impl Operator<TickValue<Decimal>, Output = TickValue<De
             low
         })
     };
-    close
-        .then(
-            view(|w: QueueRef<TickValue<Decimal>>| {
-                let close1 = w.get(1).map(|t| t.value).unwrap_or_default();
-                w[0].tick.with_value(close1)
-            })
-            .mux_with(high)
-            .mux_with(low),
-        )
-        .map(|((close1, high), low)| {
+
+    let cache0 = view(|w: QueueRef<TickValue<Decimal>>| w[0]);
+
+    let cache1 = view(|w: QueueRef<TickValue<Decimal>>| {
+        let close1 = w.get(1).map(|t| t.value);
+        w[0].tick.with_value(close1)
+    });
+
+    // rma = (1 - 1/l) * x + 1/l * rma[1]
+    let alpha = Decimal::ONE / length;
+    let rma = periodic::<2, _, _, _>(
+        2,
+        period,
+        peroidic_fn(
+            move |w: QueueRef<TickValue<Decimal>>, x: TickValue<Decimal>, _n| {
+                let rma1 = w.get(1).map(|t| t.value).unwrap_or(x.value);
+                x.tick
+                    .with_value((Decimal::ONE - alpha) * x.value + alpha * rma1)
+            },
+        ),
+    );
+
+    let atr = map(
+        |(((_close0, close1), high), low): (
+            ((TickValue<Decimal>, TickValue<Option<Decimal>>), Decimal),
+            Decimal,
+        )| {
             close1.map(|close1| {
-                (high - low)
-                    .max((close1 - high).abs())
-                    .max((close1 - low).abs())
+                close1
+                    .map(|close1| {
+                        (high - low)
+                            .max((close1 - high).abs())
+                            .max((close1 - low).abs())
+                    })
+                    .unwrap_or_default()
             })
+        },
+    )
+    .then(rma)
+    .then(view(|w| w[0]));
+
+    // long = true if last >= tsl[1] && !long[1]
+    //        false if last <= tsl[1] && long[1]
+    //        long[1] otherwise
+    // tsl = down if last >= tsl[1] && !long[1]
+    //       up if last <= tsl[1] && long[1]
+    //       max(tsl[1], down) if long[1]
+    //       min(tsl[1], up) if !long[1]
+    let tsl = periodic::<2, _, _, _>(
+        2,
+        period,
+        peroidic_fn(
+            |w: QueueRef<TickValue<(Decimal, bool)>>,
+             x: TickValue<(Decimal, Decimal, Decimal)>,
+             _n| {
+                if let Some(tsl1) = w.get(1) {
+                    let TickValue {
+                        tick,
+                        value: (last, up, down),
+                    } = x;
+                    let long1 = tsl1.value.1;
+                    let tsl1 = tsl1.value.0;
+                    let v = if long1 {
+                        let cross = last <= tsl1;
+                        let tsl = if cross { up } else { tsl1.max(down) };
+                        (tsl, !cross)
+                    } else {
+                        let cross = last >= tsl1;
+                        let tsl = if cross { down } else { tsl1.min(up) };
+                        (tsl, cross)
+                    };
+                    tick.with_value(v)
+                } else {
+                    x.map(|(_, _, down)| (down, true))
+                }
+            },
+        ),
+    )
+    .then(view(|w: QueueRef<TickValue<(Decimal, bool)>>| {
+        w[0].map(|v| v.0)
+    }));
+
+    close
+        .then(cache0.mux_with(cache1).mux_with(high).mux_with(low))
+        .then(id().mux_with(atr))
+        .map(move |((((last, _close1), high), low), atr)| {
+            let bias = factor * atr.value;
+            let up = high + bias;
+            let down = low - bias;
+            last.map(|last| (last, up, down))
         })
+        .then(tsl)
         .into_operator()
 }
 
 fn main() {
     let period = Period::seconds(UtcOffset::UTC, 2);
-    let mut op = tr(period);
+    let mut op = tsl(dec!(3), dec!(1), period);
 
     for x in [
-        TickValue::new(datetime!(2022-09-22 00:00:00 +00:00), dec!(1)),
-        TickValue::new(datetime!(2022-09-22 00:00:01 +00:00), dec!(2)),
-        TickValue::new(datetime!(2022-09-22 00:00:02 +00:00), dec!(3)),
-        TickValue::new(datetime!(2022-09-22 00:00:03 +00:00), dec!(4)),
-        TickValue::new(datetime!(2022-09-22 00:00:04 +00:00), dec!(5)),
-        TickValue::new(datetime!(2022-09-22 00:00:05 +00:00), dec!(6)),
+        TickValue::new(datetime!(2022-09-22 00:00:00 +00:00), dec!(100)),
+        TickValue::new(datetime!(2022-09-22 00:00:01 +00:00), dec!(102)),
+        TickValue::new(datetime!(2022-09-22 00:00:02 +00:00), dec!(103)),
+        TickValue::new(datetime!(2022-09-22 00:00:03 +00:00), dec!(104)),
+        TickValue::new(datetime!(2022-09-22 00:00:04 +00:00), dec!(105)),
+        TickValue::new(datetime!(2022-09-22 00:00:05 +00:00), dec!(106)),
+        TickValue::new(datetime!(2022-09-22 00:00:06 +00:00), dec!(100)),
+        TickValue::new(datetime!(2022-09-22 00:00:07 +00:00), dec!(102)),
+        TickValue::new(datetime!(2022-09-22 00:00:08 +00:00), dec!(103)),
+        TickValue::new(datetime!(2022-09-22 00:00:09 +00:00), dec!(104)),
+        TickValue::new(datetime!(2022-09-22 00:00:10 +00:00), dec!(105)),
+        TickValue::new(datetime!(2022-09-22 00:00:11 +00:00), dec!(106)),
     ] {
         println!("{}", op.next(x));
     }

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -11,6 +11,6 @@ pub use operator::{identity::id, map::map, mux::mux, GatOperator, GatOperatorExt
 pub use tick_operator::{map_tick::map_t, TickGatOperatorExt};
 pub use tumbling_operator::{
     operator::{tumbling, view, TumblingOperator},
-    periodic::{cache, periodic, periodic_with, Periodic},
+    periodic::{cache, periodic, periodic_with, peroidic_fn, Periodic},
     queue::{circular::Circular, Change, Queue, QueueRef, Tumbling},
 };

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -10,7 +10,7 @@ pub mod tumbling_operator;
 pub use operator::{identity::id, map::map, mux::mux, GatOperator, GatOperatorExt};
 pub use tick_operator::{map_tick::map_t, TickGatOperatorExt};
 pub use tumbling_operator::{
-    operator::{tumbling, TumblingOperator},
+    operator::{tumbling, view, TumblingOperator},
     periodic::{cache, periodic, periodic_with, Periodic},
-    queue::{circular::Circular, Change, Queue, Tumbling},
+    queue::{circular::Circular, Change, Queue, QueueRef, Tumbling},
 };

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -9,3 +9,7 @@ pub mod tumbling_operator;
 
 pub use operator::{identity::id, map::map, mux::mux, GatOperator, GatOperatorExt};
 pub use tick_operator::{map_tick::map_t, TickGatOperatorExt};
+pub use tumbling_operator::{
+    operator::{tumbling, TumblingOperator},
+    queue::{circular::Circular, Change, Queue, Tumbling},
+};

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -1,4 +1,8 @@
-/// The definition of the operator of indicators and some helpers
+/// The definition of the operators of indicators and some helpers
 pub mod operator;
 
+/// Helpers for operators with [`Tickable`](crate::Tickable) output.
+pub mod tick_operator;
+
 pub use operator::{identity::id, map::map, mux::mux, Operator, OperatorExt};
+pub use tick_operator::{tick_map::map_t, TickOperatorExt};

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -1,4 +1,4 @@
 /// The definition of the operator of indicators and some helpers
 pub mod operator;
 
-pub use operator::{identity::id, map::map, Operator, OperatorExt};
+pub use operator::{identity::id, map::map, mux::mux, Operator, OperatorExt};

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -1,0 +1,4 @@
+/// The definition of the operator of indicators and some helpers
+pub mod operator;
+
+pub use operator::{identity::id, map::map, Operator, OperatorExt};

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -4,5 +4,8 @@ pub mod operator;
 /// Helpers for operators with [`Tickable`](crate::Tickable) output.
 pub mod tick_operator;
 
+/// Tumbling operator.
+pub mod tumbling_operator;
+
 pub use operator::{identity::id, map::map, mux::mux, GatOperator, GatOperatorExt};
 pub use tick_operator::{map_tick::map_t, TickGatOperatorExt};

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -4,5 +4,5 @@ pub mod operator;
 /// Helpers for operators with [`Tickable`](crate::Tickable) output.
 pub mod tick_operator;
 
-pub use operator::{identity::id, map::map, mux::mux, Operator, OperatorExt};
-pub use tick_operator::{tick_map::map_t, TickOperatorExt};
+pub use operator::{identity::id, map::map, mux::mux, GatOperator, GatOperatorExt};
+pub use tick_operator::{tick_map::map_t, TickGatOperatorExt};

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -11,5 +11,6 @@ pub use operator::{identity::id, map::map, mux::mux, GatOperator, GatOperatorExt
 pub use tick_operator::{map_tick::map_t, TickGatOperatorExt};
 pub use tumbling_operator::{
     operator::{tumbling, TumblingOperator},
+    periodic::{cache, periodic, periodic_with, Periodic},
     queue::{circular::Circular, Change, Queue, Tumbling},
 };

--- a/src/gat/mod.rs
+++ b/src/gat/mod.rs
@@ -5,4 +5,4 @@ pub mod operator;
 pub mod tick_operator;
 
 pub use operator::{identity::id, map::map, mux::mux, GatOperator, GatOperatorExt};
-pub use tick_operator::{tick_map::map_t, TickGatOperatorExt};
+pub use tick_operator::{map_tick::map_t, TickGatOperatorExt};

--- a/src/gat/operator/identity.rs
+++ b/src/gat/operator/identity.rs
@@ -1,0 +1,45 @@
+use core::marker::PhantomData;
+
+use super::Operator;
+
+/// Identity operator.
+pub struct Identity<I>(PhantomData<I>);
+
+impl<I> core::fmt::Debug for Identity<I> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Identity").finish()
+    }
+}
+
+impl<I> Clone for Identity<I> {
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<I> Copy for Identity<I> {}
+
+impl<I> Default for Identity<I> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<I> Operator<I> for Identity<I> {
+    type Output<'out> = I
+    where
+        Self: 'out,
+        I: 'out;
+
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        input
+    }
+}
+
+/// Create a [`Identity`] operator.
+pub fn id<I>() -> Identity<I> {
+    Identity(PhantomData)
+}

--- a/src/gat/operator/identity.rs
+++ b/src/gat/operator/identity.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use super::Operator;
+use super::GatOperator;
 
 /// Identity operator.
 pub struct Identity<I>(PhantomData<I>);
@@ -25,7 +25,7 @@ impl<I> Default for Identity<I> {
     }
 }
 
-impl<I> Operator<I> for Identity<I> {
+impl<I> GatOperator<I> for Identity<I> {
     type Output<'out> = I
     where
         Self: 'out,

--- a/src/gat/operator/map.rs
+++ b/src/gat/operator/map.rs
@@ -1,0 +1,35 @@
+use super::Operator;
+
+/// Operator returns by [`map`].
+#[derive(Debug, Clone, Copy)]
+pub struct Map<F>(pub(super) F);
+
+/// Convert the input directly.
+/// ```
+/// use indicator::gat::*;
+///
+/// fn plus_one() -> impl for<'out> Operator<usize, Output<'out> = usize> {
+///     map(|x| x + 1)
+/// }
+/// ```
+pub fn map<I, O, F>(f: F) -> Map<F>
+where
+    F: FnMut(I) -> O,
+{
+    Map(f)
+}
+
+impl<I, O, F> Operator<I> for Map<F>
+where
+    F: FnMut(I) -> O,
+{
+    type Output<'out> = O where F: 'out, I: 'out;
+
+    #[inline]
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        (self.0)(input)
+    }
+}

--- a/src/gat/operator/map.rs
+++ b/src/gat/operator/map.rs
@@ -1,4 +1,4 @@
-use super::Operator;
+use super::GatOperator;
 
 /// Operator returns by [`map`].
 #[derive(Debug, Clone, Copy)]
@@ -8,7 +8,7 @@ pub struct Map<F>(pub(super) F);
 /// ```
 /// use indicator::gat::*;
 ///
-/// fn plus_one() -> impl for<'out> Operator<usize, Output<'out> = usize> {
+/// fn plus_one() -> impl for<'out> GatOperator<usize, Output<'out> = usize> {
 ///     map(|x| x + 1)
 /// }
 /// ```
@@ -19,7 +19,7 @@ where
     Map(f)
 }
 
-impl<I, O, F> Operator<I> for Map<F>
+impl<I, O, F> GatOperator<I> for Map<F>
 where
     F: FnMut(I) -> O,
 {

--- a/src/gat/operator/mod.rs
+++ b/src/gat/operator/mod.rs
@@ -1,0 +1,62 @@
+use self::{map::Map, then::Then};
+
+/// Combine two operators.
+pub mod then;
+
+/// Convert the input directly.
+pub mod map;
+
+/// Identity operator.
+pub mod identity;
+
+/// Operator that produces indicator values by calling `next` method.
+/// It is just a version of `FnMut` with generic associated (lifetime) output.
+pub trait Operator<I> {
+    /// The output type.
+    type Output<'out>
+    where
+        Self: 'out,
+        I: 'out;
+
+    /// Produce the next indicator value according to the given input.
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out;
+}
+
+/// Helpers for [`Operator`].
+pub trait OperatorExt<I>: Operator<I> {
+    /// Combine two operators.
+    /// ```
+    /// use indicator::gat::*;
+    ///
+    /// fn plus_one() -> impl for<'out> Operator<usize, Output<'out> = usize> {
+    ///     id().then(map(|x| x + 1))
+    /// }
+    /// ```
+    fn then<P>(self, other: P) -> Then<Self, P>
+    where
+        Self: Sized,
+        P: for<'out> Operator<Self::Output<'out>>,
+    {
+        Then(self, other)
+    }
+
+    /// Convert the output.
+    /// ```
+    /// use indicator::gat::*;
+    ///
+    /// fn plus_two() -> impl for<'out> Operator<usize, Output<'out> = usize> {
+    ///     id().then(map(|x| x + 2))
+    /// }
+    /// ```
+    fn map<O, F>(self, f: F) -> Then<Self, Map<F>>
+    where
+        Self: Sized,
+        F: FnMut(I) -> O,
+    {
+        Then(self, Map(f))
+    }
+}
+
+impl<I, P> OperatorExt<I> for P where P: Operator<I> {}

--- a/src/gat/operator/mod.rs
+++ b/src/gat/operator/mod.rs
@@ -94,6 +94,33 @@ pub trait OperatorExt<I>: Operator<I> {
     {
         Mux(self, other)
     }
+
+    /// Convert into a non-GAT operator.
+    fn into_operator<O>(self) -> Op<Self>
+    where
+        Self: for<'out> Operator<I, Output<'out> = O> + 'static,
+        Self: Sized,
+        I: 'static,
+    {
+        Op(self)
+    }
 }
 
 impl<I, P> OperatorExt<I> for P where P: Operator<I> {}
+
+/// Wrapper that Convert `P` into a non-GAT operator.
+#[derive(Debug, Clone, Copy)]
+pub struct Op<P>(P);
+
+impl<I, O, P> crate::Operator<I> for Op<P>
+where
+    P: for<'out> Operator<I, Output<'out> = O> + 'static,
+    I: 'static,
+{
+    type Output = O;
+
+    #[inline]
+    fn next(&mut self, input: I) -> Self::Output {
+        self.0.next(input)
+    }
+}

--- a/src/gat/operator/mod.rs
+++ b/src/gat/operator/mod.rs
@@ -27,6 +27,23 @@ pub trait Operator<I> {
         I: 'out;
 }
 
+impl<'a, I, P> Operator<I> for &'a mut P
+where
+    P: Operator<I>,
+{
+    type Output<'out> = P::Output<'out>
+    where
+        Self: 'out,
+        I: 'out;
+
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        (*self).next(input)
+    }
+}
+
 /// Helpers for [`Operator`].
 pub trait OperatorExt<I>: Operator<I> {
     /// Combine two operators.

--- a/src/gat/operator/mux.rs
+++ b/src/gat/operator/mux.rs
@@ -1,4 +1,4 @@
-use super::Operator;
+use super::GatOperator;
 
 /// Operator returns by [`mux`].
 #[derive(Debug, Clone, Copy)]
@@ -8,24 +8,24 @@ pub struct Mux<P1, P2>(pub(super) P1, pub(super) P2);
 /// ```
 /// use indicator::gat::*;
 ///
-/// fn plus_mul() -> impl for<'out> Operator<usize, Output<'out> = usize> {
+/// fn plus_mul() -> impl for<'out> GatOperator<usize, Output<'out> = usize> {
 ///     mux(map(|x| x + 1), map(|x| x * 2)).map(|(x, y)| x + y)
 /// }
 /// ```
 pub fn mux<I, P1, P2>(op1: P1, op2: P2) -> Mux<P1, P2>
 where
     I: Clone,
-    P1: Operator<I>,
-    P2: Operator<I>,
+    P1: GatOperator<I>,
+    P2: GatOperator<I>,
 {
     Mux(op1, op2)
 }
 
-impl<I, P1, P2> Operator<I> for Mux<P1, P2>
+impl<I, P1, P2> GatOperator<I> for Mux<P1, P2>
 where
     I: Clone,
-    P1: Operator<I>,
-    P2: Operator<I>,
+    P1: GatOperator<I>,
+    P2: GatOperator<I>,
 {
     type Output<'out> = (P1::Output<'out>, P2::Output<'out>)
     where

--- a/src/gat/operator/mux.rs
+++ b/src/gat/operator/mux.rs
@@ -1,0 +1,42 @@
+use super::Operator;
+
+/// Operator returns by [`mux`].
+#[derive(Debug, Clone, Copy)]
+pub struct Mux<P1, P2>(pub(super) P1, pub(super) P2);
+
+/// Use two operators simultaneously.
+/// ```
+/// use indicator::gat::*;
+///
+/// fn plus_mul() -> impl for<'out> Operator<usize, Output<'out> = usize> {
+///     mux(map(|x| x + 1), map(|x| x * 2)).map(|(x, y)| x + y)
+/// }
+/// ```
+pub fn mux<I, P1, P2>(op1: P1, op2: P2) -> Mux<P1, P2>
+where
+    I: Clone,
+    P1: Operator<I>,
+    P2: Operator<I>,
+{
+    Mux(op1, op2)
+}
+
+impl<I, P1, P2> Operator<I> for Mux<P1, P2>
+where
+    I: Clone,
+    P1: Operator<I>,
+    P2: Operator<I>,
+{
+    type Output<'out> = (P1::Output<'out>, P2::Output<'out>)
+    where
+        I: 'out,
+        P1: 'out,
+        P2: 'out;
+
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        (self.0.next(input.clone()), self.1.next(input))
+    }
+}

--- a/src/gat/operator/then.rs
+++ b/src/gat/operator/then.rs
@@ -1,0 +1,25 @@
+use super::Operator;
+
+/// The [`Operator`] produces by [`then`](super::OperatorExt).
+#[derive(Debug, Clone, Copy)]
+pub struct Then<P1, P2>(pub(super) P1, pub(super) P2);
+
+impl<I, P1, P2> Operator<I> for Then<P1, P2>
+where
+    P1: Operator<I>,
+    P2: for<'out> Operator<P1::Output<'out>>,
+{
+    type Output<'out> = <P2 as Operator<<P1 as Operator<I>>::Output<'out>>>::Output<'out>
+    where
+        I: 'out,
+        P1: 'out,
+        P2: 'out;
+
+    #[inline]
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        self.1.next(self.0.next(input))
+    }
+}

--- a/src/gat/operator/then.rs
+++ b/src/gat/operator/then.rs
@@ -2,7 +2,7 @@ use super::Operator;
 
 /// The [`Operator`] produces by [`then`](super::OperatorExt).
 #[derive(Debug, Clone, Copy)]
-pub struct Then<P1, P2>(pub(super) P1, pub(super) P2);
+pub struct Then<P1, P2>(pub(crate) P1, pub(crate) P2);
 
 impl<I, P1, P2> Operator<I> for Then<P1, P2>
 where

--- a/src/gat/operator/then.rs
+++ b/src/gat/operator/then.rs
@@ -1,15 +1,15 @@
-use super::Operator;
+use super::GatOperator;
 
-/// The [`Operator`] produces by [`then`](super::OperatorExt).
+/// The [`GatOperator`] produces by [`then`](super::OperatorExt).
 #[derive(Debug, Clone, Copy)]
 pub struct Then<P1, P2>(pub(crate) P1, pub(crate) P2);
 
-impl<I, P1, P2> Operator<I> for Then<P1, P2>
+impl<I, P1, P2> GatOperator<I> for Then<P1, P2>
 where
-    P1: Operator<I>,
-    P2: for<'out> Operator<P1::Output<'out>>,
+    P1: GatOperator<I>,
+    P2: for<'out> GatOperator<P1::Output<'out>>,
 {
-    type Output<'out> = <P2 as Operator<<P1 as Operator<I>>::Output<'out>>>::Output<'out>
+    type Output<'out> = <P2 as GatOperator<<P1 as GatOperator<I>>::Output<'out>>>::Output<'out>
     where
         I: 'out,
         P1: 'out,

--- a/src/gat/tick_operator/mod.rs
+++ b/src/gat/tick_operator/mod.rs
@@ -1,11 +1,11 @@
 use crate::Tickable;
 
-use self::tick_map::TickMap;
+use self::map_tick::MapTick;
 
-use super::{map_t, operator::then::Then, GatOperator};
+use super::{operator::then::Then, GatOperator};
 
 /// Map over the ticked value.
-pub mod tick_map;
+pub mod map_tick;
 
 /// Helpers for the operaors with [`Tickable`] output.
 pub trait TickGatOperatorExt<I>: GatOperator<I>
@@ -17,15 +17,15 @@ where
     /// use indicator::{gat::*, TickValue};
     ///
     /// fn plus_one() -> impl for<'out> GatOperator<TickValue<usize>, Output<'out> = TickValue<usize>> {
-    ///     id().map_t(|x| x + 1)
+    ///     id().map_tick(map(|x| x + 1))
     /// }
     /// ```
-    fn map_t<U, F>(self, f: F) -> Then<Self, TickMap<F>>
+    fn map_tick<P>(self, op: P) -> Then<Self, MapTick<P>>
     where
         Self: Sized,
-        F: FnMut(<Self::Output<'_> as Tickable>::Value) -> U,
+        P: for<'out> GatOperator<<Self::Output<'out> as Tickable>::Value>,
     {
-        Then(self, map_t(f))
+        Then(self, MapTick(op))
     }
 }
 

--- a/src/gat/tick_operator/mod.rs
+++ b/src/gat/tick_operator/mod.rs
@@ -2,13 +2,13 @@ use crate::Tickable;
 
 use self::tick_map::TickMap;
 
-use super::{map_t, operator::then::Then, Operator};
+use super::{map_t, operator::then::Then, GatOperator};
 
 /// Map over the ticked value.
 pub mod tick_map;
 
 /// Helpers for the operaors with [`Tickable`] output.
-pub trait TickOperatorExt<I>: Operator<I>
+pub trait TickGatOperatorExt<I>: GatOperator<I>
 where
     for<'out> Self::Output<'out>: Tickable,
 {
@@ -16,7 +16,7 @@ where
     /// ```
     /// use indicator::{gat::*, TickValue};
     ///
-    /// fn plus_one() -> impl for<'out> Operator<TickValue<usize>, Output<'out> = TickValue<usize>> {
+    /// fn plus_one() -> impl for<'out> GatOperator<TickValue<usize>, Output<'out> = TickValue<usize>> {
     ///     id().map_t(|x| x + 1)
     /// }
     /// ```
@@ -29,9 +29,9 @@ where
     }
 }
 
-impl<I, P> TickOperatorExt<I> for P
+impl<I, P> TickGatOperatorExt<I> for P
 where
-    P: Operator<I>,
+    P: GatOperator<I>,
     for<'out> P::Output<'out>: Tickable,
 {
 }

--- a/src/gat/tick_operator/mod.rs
+++ b/src/gat/tick_operator/mod.rs
@@ -1,0 +1,37 @@
+use crate::Tickable;
+
+use self::tick_map::TickMap;
+
+use super::{map_t, operator::then::Then, Operator};
+
+/// Map over the ticked value.
+pub mod tick_map;
+
+/// Helpers for the operaors with [`Tickable`] output.
+pub trait TickOperatorExt<I>: Operator<I>
+where
+    for<'out> Self::Output<'out>: Tickable,
+{
+    /// Map over the output tick value.
+    /// ```
+    /// use indicator::{gat::*, TickValue};
+    ///
+    /// fn plus_one() -> impl for<'out> Operator<TickValue<usize>, Output<'out> = TickValue<usize>> {
+    ///     id().map_t(|x| x + 1)
+    /// }
+    /// ```
+    fn map_t<U, F>(self, f: F) -> Then<Self, TickMap<F>>
+    where
+        Self: Sized,
+        F: FnMut(<Self::Output<'_> as Tickable>::Value) -> U,
+    {
+        Then(self, map_t(f))
+    }
+}
+
+impl<I, P> TickOperatorExt<I> for P
+where
+    P: Operator<I>,
+    for<'out> P::Output<'out>: Tickable,
+{
+}

--- a/src/gat/tick_operator/tick_map.rs
+++ b/src/gat/tick_operator/tick_map.rs
@@ -1,0 +1,38 @@
+use crate::{TickValue, Tickable};
+
+use super::Operator;
+
+/// Operator returns by [`map_t`].
+#[derive(Debug, Clone, Copy)]
+pub struct TickMap<F>(pub(super) F);
+
+/// Convert the value of inside the tickabe input directly.
+/// ```
+/// use indicator::{gat::*, TickValue};
+///
+/// fn plus_one() -> impl for<'out> Operator<TickValue<usize>, Output<'out> = TickValue<usize>> {
+///     map_t(|x| x + 1)
+/// }
+/// ```
+pub fn map_t<I, O, F>(f: F) -> TickMap<F>
+where
+    F: FnMut(I) -> O,
+{
+    TickMap(f)
+}
+
+impl<I, O, F> Operator<I> for TickMap<F>
+where
+    I: Tickable,
+    F: FnMut(I::Value) -> O,
+{
+    type Output<'out> = TickValue<O> where F: 'out, I: 'out;
+
+    #[inline]
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        input.into_tick_value().map(&mut self.0)
+    }
+}

--- a/src/gat/tick_operator/tick_map.rs
+++ b/src/gat/tick_operator/tick_map.rs
@@ -1,6 +1,6 @@
 use crate::{TickValue, Tickable};
 
-use super::Operator;
+use super::GatOperator;
 
 /// Operator returns by [`map_t`].
 #[derive(Debug, Clone, Copy)]
@@ -10,7 +10,7 @@ pub struct TickMap<F>(pub(super) F);
 /// ```
 /// use indicator::{gat::*, TickValue};
 ///
-/// fn plus_one() -> impl for<'out> Operator<TickValue<usize>, Output<'out> = TickValue<usize>> {
+/// fn plus_one() -> impl for<'out> GatOperator<TickValue<usize>, Output<'out> = TickValue<usize>> {
 ///     map_t(|x| x + 1)
 /// }
 /// ```
@@ -21,7 +21,7 @@ where
     TickMap(f)
 }
 
-impl<I, O, F> Operator<I> for TickMap<F>
+impl<I, O, F> GatOperator<I> for TickMap<F>
 where
     I: Tickable,
     F: FnMut(I::Value) -> O,

--- a/src/gat/tumbling_operator/mod.rs
+++ b/src/gat/tumbling_operator/mod.rs
@@ -1,2 +1,5 @@
 /// Queue that is used to implement tumbling operators.
 pub mod queue;
+
+/// Tumbling Operator.
+pub mod operator;

--- a/src/gat/tumbling_operator/mod.rs
+++ b/src/gat/tumbling_operator/mod.rs
@@ -3,3 +3,6 @@ pub mod queue;
 
 /// Tumbling Operator.
 pub mod operator;
+
+/// Periodic Operator (aka rolling operator).
+pub mod periodic;

--- a/src/gat/tumbling_operator/mod.rs
+++ b/src/gat/tumbling_operator/mod.rs
@@ -1,0 +1,2 @@
+/// Queue that is used to implement tumbling operators.
+pub mod queue;

--- a/src/gat/tumbling_operator/operator.rs
+++ b/src/gat/tumbling_operator/operator.rs
@@ -1,0 +1,54 @@
+use crate::gat::GatOperator;
+
+use super::queue::{circular::Circular, Queue, Tumbling};
+
+/// Tumbling Operator.
+pub struct TumblingOperator<Q: Queue, P> {
+    queue: Tumbling<Q>,
+    op: P,
+}
+
+impl<Q: Queue, P> TumblingOperator<Q, P> {
+    /// Create a new tumbling operator.
+    pub fn with_queue<I>(queue: Q, op: P) -> Self
+    where
+        Q: Queue,
+        P: FnMut(&mut Tumbling<Q>, I),
+    {
+        Self {
+            op,
+            queue: Tumbling::new(queue),
+        }
+    }
+}
+
+impl<I, Q, P> GatOperator<I> for TumblingOperator<Q, P>
+where
+    Q: Queue,
+    P: FnMut(&mut Tumbling<Q>, I),
+{
+    type Output<'out> = &'out Tumbling<Q>
+    where
+        Self: 'out,
+        I: 'out;
+
+    fn next<'out>(&'out mut self, input: I) -> Self::Output<'out>
+    where
+        I: 'out,
+    {
+        let Self { queue, op } = self;
+        (op)(queue, input);
+        queue
+    }
+}
+
+/// Create a new tumbling operator with circular queue.
+pub fn tumbling<const N: usize, I, T, P>(
+    length: usize,
+    op: P,
+) -> TumblingOperator<Circular<T, N>, P>
+where
+    P: FnMut(&mut Tumbling<Circular<T, N>>, I),
+{
+    TumblingOperator::with_queue(Circular::with_capacity(length), op)
+}

--- a/src/gat/tumbling_operator/periodic.rs
+++ b/src/gat/tumbling_operator/periodic.rs
@@ -20,6 +20,22 @@ where
     fn push(&mut self, queue: &Tumbling<Q>, event: I) -> Self::Output;
 }
 
+impl<Q, I, O, F> Periodic<I, Q> for F
+where
+    Q: Queue<Item = O>,
+    F: FnMut(&Tumbling<Q>, I, bool) -> O,
+{
+    type Output = O;
+
+    fn swap(&mut self, queue: &Tumbling<Q>, event: I) -> Self::Output {
+        (self)(queue, event, false)
+    }
+
+    fn push(&mut self, queue: &Tumbling<Q>, event: I) -> Self::Output {
+        (self)(queue, event, true)
+    }
+}
+
 /// Identity periodic operation.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Identity;

--- a/src/gat/tumbling_operator/periodic.rs
+++ b/src/gat/tumbling_operator/periodic.rs
@@ -1,0 +1,110 @@
+use crate::{prelude::GatOperator, Period, Tick, Tickable, TumblingWindow};
+
+use super::{
+    operator::{Operation, TumblingOperator},
+    queue::{circular::Circular, Queue, Tumbling},
+};
+
+/// Periodic Operation.
+pub trait Periodic<I, Q>
+where
+    Q: Queue<Item = Self::Output>,
+{
+    /// The output type.
+    type Output;
+
+    /// Received an event from the same period.
+    fn swap(&mut self, queue: &Tumbling<Q>, event: I) -> Self::Output;
+
+    /// Received an event from a new period.
+    fn push(&mut self, queue: &Tumbling<Q>, event: I) -> Self::Output;
+}
+
+/// Identity periodic operation.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Identity;
+
+impl<I, Q> Periodic<I, Q> for Identity
+where
+    Q: Queue<Item = I>,
+{
+    type Output = I;
+
+    fn swap(&mut self, _queue: &Tumbling<Q>, event: I) -> Self::Output {
+        event
+    }
+
+    fn push(&mut self, _queue: &Tumbling<Q>, event: I) -> Self::Output {
+        event
+    }
+}
+
+/// Operation used in tumbling.
+#[derive(Debug, Clone, Copy)]
+pub struct Op<P> {
+    last: Tick,
+    period: Period,
+    op: P,
+}
+
+impl<P> Op<P> {
+    fn new(period: Period, op: P) -> Self {
+        Self {
+            last: Tick::BIG_BANG,
+            period,
+            op,
+        }
+    }
+}
+
+impl<I, Q, P> Operation<I, Q> for Op<P>
+where
+    I: Tickable,
+    P: Periodic<I, Q>,
+    Q: Queue<Item = P::Output>,
+{
+    fn step(&mut self, queue: &mut Tumbling<Q>, event: I) {
+        if self.period.same_window(&self.last, event.tick()) {
+            let output = self.op.swap(queue, event);
+            queue.swap(output);
+        } else {
+            self.last = *event.tick();
+            let output = self.op.push(queue, event);
+            queue.push(output);
+        }
+    }
+}
+
+/// Create a periodic operator.
+pub fn periodic_with<Q, I, P>(length: usize, period: Period, op: P) -> TumblingOperator<Q, Op<P>>
+where
+    I: Tickable,
+    P: Periodic<I, Q>,
+    Q: Queue<Item = P::Output>,
+{
+    TumblingOperator::with_queue(Q::with_capacity(length), Op::new(period, op))
+}
+
+/// Create a new periodic operator with circular queue.
+pub fn periodic<const N: usize, I, O, P>(
+    length: usize,
+    period: Period,
+    op: P,
+) -> TumblingOperator<Circular<O, N>, Op<P>>
+where
+    I: Tickable,
+    P: Periodic<I, Circular<O, N>, Output = O>,
+{
+    TumblingOperator::with_queue(Circular::with_capacity(length), Op::new(period, op))
+}
+
+/// Create a cache operator.
+pub fn cache<const N: usize, I>(
+    length: usize,
+    period: Period,
+) -> impl for<'out> GatOperator<I, Output<'out> = &'out Tumbling<Circular<I, N>>>
+where
+    I: Tickable + 'static,
+{
+    periodic(length, period, Identity)
+}

--- a/src/gat/tumbling_operator/periodic.rs
+++ b/src/gat/tumbling_operator/periodic.rs
@@ -2,7 +2,7 @@ use crate::{prelude::GatOperator, Period, Tick, Tickable, TumblingWindow};
 
 use super::{
     operator::{Operation, TumblingOperator},
-    queue::{circular::Circular, Queue, Tumbling},
+    queue::{circular::Circular, Collection, Queue, QueueRef, Tumbling},
 };
 
 /// Periodic Operation.
@@ -92,13 +92,13 @@ where
 }
 
 /// Create a periodic operator.
-pub fn periodic_with<Q, I, P>(length: usize, period: Period, op: P) -> TumblingOperator<Q, Op<P>>
+pub fn periodic_with<Q, I, P>(queue: Q, period: Period, op: P) -> TumblingOperator<Q, Op<P>>
 where
     I: Tickable,
     P: Periodic<I, Q>,
     Q: Queue<Item = P::Output>,
 {
-    TumblingOperator::with_queue(Q::with_capacity(length), Op::new(period, op))
+    TumblingOperator::with_queue(queue, Op::new(period, op))
 }
 
 /// Create a new periodic operator with circular queue.
@@ -118,9 +118,9 @@ where
 pub fn cache<const N: usize, I>(
     length: usize,
     period: Period,
-) -> impl for<'out> GatOperator<I, Output<'out> = &'out Tumbling<Circular<I, N>>>
+) -> impl for<'out> GatOperator<I, Output<'out> = QueueRef<'out, I>>
 where
     I: Tickable + 'static,
 {
-    periodic(length, period, Identity)
+    periodic::<N, _, _, _>(length, period, Identity)
 }

--- a/src/gat/tumbling_operator/queue/circular.rs
+++ b/src/gat/tumbling_operator/queue/circular.rs
@@ -16,7 +16,7 @@ use super::Queue;
 
 /// Circular Queue backed by [`TinyVec`].
 #[derive(Debug, Clone)]
-pub struct Circular<T, const N: usize> {
+pub struct Circular<T, const N: usize = 1> {
     inner: TinyVec<[Option<T>; N]>,
     cap: usize,
     next_tail: usize,

--- a/src/gat/tumbling_operator/queue/circular.rs
+++ b/src/gat/tumbling_operator/queue/circular.rs
@@ -12,7 +12,7 @@
 
 use tinyvec::TinyVec;
 
-use super::Queue;
+use super::{Collection, Queue};
 
 /// Circular Queue backed by [`TinyVec`].
 #[derive(Debug, Clone)]
@@ -64,9 +64,7 @@ impl<T, const N: usize> Circular<T, N> {
     }
 }
 
-impl<T, const N: usize> Queue for Circular<T, N> {
-    type Item = T;
-
+impl<T, const N: usize> Collection for Circular<T, N> {
     fn with_capacity(cap: usize) -> Self {
         assert!(cap != 0, "capacity cannot be zero");
         Self {
@@ -76,6 +74,10 @@ impl<T, const N: usize> Queue for Circular<T, N> {
             head: None,
         }
     }
+}
+
+impl<T, const N: usize> Queue for Circular<T, N> {
+    type Item = T;
 
     fn enque(&mut self, item: Self::Item) {
         let next_tail = self.entry_next_tail();

--- a/src/gat/tumbling_operator/queue/circular.rs
+++ b/src/gat/tumbling_operator/queue/circular.rs
@@ -1,0 +1,196 @@
+//! # A circlar queue implemenation
+//! ## The mind model
+//! ```markdown
+//! |------------------ grow ------------------>|
+//! [0, .., head, .., tail, next_tail, .., cap-1]
+//! ```
+//! or
+//! ```markdown
+//! |------------------ grow ------------------>|
+//! [0, .., tail, next_tail, .., head, .., cap-1]
+//! ```
+
+use tinyvec::TinyVec;
+
+use super::Queue;
+
+/// Circular Queue backed by [`TinyVec`].
+#[derive(Debug, Clone)]
+pub struct Circular<T, const N: usize> {
+    inner: TinyVec<[Option<T>; N]>,
+    cap: usize,
+    next_tail: usize,
+    head: Option<usize>,
+}
+
+impl<T, const N: usize> Circular<T, N> {
+    fn entry_next_tail(&mut self) -> &mut Option<T> {
+        // Assumption: `next_tail` must be a valid position, that is
+        // 1) `0 <= next_tail < cap`,
+        // 2) `inner[next_tail - 1]` is `Some` or `next_tail == 0`.
+        if self.inner.get(self.next_tail).is_none() {
+            // |---- grow ---->|
+            // |2|1|0|next_tail|
+            self.inner.push(None);
+        }
+        self.inner.get_mut(self.next_tail).unwrap()
+    }
+
+    fn move_next_tail(&mut self) {
+        if self.head.is_none() {
+            self.head = Some(self.next_tail);
+        }
+        self.next_tail = (self.next_tail + 1) % self.cap;
+    }
+
+    fn move_head(&mut self) {
+        let head = (self.head.unwrap() + 1) % self.cap;
+        if head == self.next_tail {
+            self.head = None;
+        } else {
+            self.head = Some(head);
+        }
+    }
+
+    fn to_idx(&self, idx: usize) -> Option<usize> {
+        let offset = idx + 1;
+        if self.next_tail >= offset {
+            Some(self.next_tail - offset)
+        } else if self.next_tail + self.cap >= offset {
+            Some(self.next_tail + self.cap - offset)
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, const N: usize> Queue for Circular<T, N> {
+    type Item = T;
+
+    fn with_capacity(cap: usize) -> Self {
+        assert!(cap != 0, "capacity cannot be zero");
+        Self {
+            inner: TinyVec::with_capacity(cap),
+            cap,
+            next_tail: 0,
+            head: None,
+        }
+    }
+
+    fn enque(&mut self, item: Self::Item) {
+        let next_tail = self.entry_next_tail();
+        assert!(next_tail.is_none(), "queue is full");
+        *next_tail = Some(item);
+        self.move_next_tail();
+    }
+
+    fn deque(&mut self) -> Option<Self::Item> {
+        let head = self.head?;
+        let item = self.inner.get_mut(head).unwrap().take();
+        self.move_head();
+        item
+    }
+
+    fn len(&self) -> usize {
+        if let Some(head) = self.head {
+            if self.next_tail > head {
+                self.next_tail - head
+            } else {
+                self.cap - (head - self.next_tail)
+            }
+        } else {
+            0
+        }
+    }
+
+    fn cap(&self) -> usize {
+        self.cap
+    }
+
+    fn get(&self, idx: usize) -> Option<&Self::Item> {
+        let idx = self.to_idx(idx)?;
+        self.inner.get(idx)?.as_ref()
+    }
+
+    fn get_mut(&mut self, idx: usize) -> Option<&mut Self::Item> {
+        let idx = self.to_idx(idx)?;
+        self.inner.get_mut(idx)?.as_mut()
+    }
+
+    #[inline]
+    fn is_inline(&self) -> bool {
+        self.inner.is_inline()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let mut queue = Circular::<_, 3>::with_capacity(3);
+        assert!(queue.inner.is_inline());
+        assert!(queue.is_empty());
+        queue.enque(1);
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.get(0), Some(&1));
+        assert!(queue.get(1).is_none());
+        assert_eq!(queue.deque(), Some(1));
+        assert_eq!(queue.len(), 0);
+        assert!(queue.get(0).is_none());
+    }
+
+    #[test]
+    fn full() {
+        let mut queue = Circular::<_, 1>::with_capacity(3);
+        assert!(queue.inner.is_heap());
+        queue.enque(1);
+        queue.enque(2);
+        queue.enque(3);
+        assert!(queue.is_full());
+        assert_eq!(queue.deque(), Some(1));
+        assert_eq!(queue.deque(), Some(2));
+        assert_eq!(queue.deque(), Some(3));
+        assert_eq!(queue.deque(), None);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn circular_1() {
+        let mut queue = Circular::<_, 1>::with_capacity(3);
+        queue.enque(1);
+        assert_eq!(queue.deque(), Some(1));
+        queue.enque(2);
+        queue.enque(3);
+        queue.enque(4);
+        assert!(queue.is_full());
+        assert_eq!(queue.deque(), Some(2));
+        assert_eq!(queue.get(0), Some(&4));
+        assert_eq!(queue.get(1), Some(&3));
+        assert_eq!(queue.get(2), None);
+        assert_eq!(queue.deque(), Some(3));
+        assert_eq!(queue.deque(), Some(4));
+        assert!(queue.is_empty());
+        assert_eq!(queue.deque(), None);
+    }
+
+    #[test]
+    fn circular_2() {
+        let mut queue = Circular::<_, 1>::with_capacity(3);
+        queue.enque(1);
+        assert_eq!(queue.deque(), Some(1));
+        queue.enque(2);
+        assert_eq!(queue.deque(), Some(2));
+        queue.enque(3);
+        assert_eq!(queue.deque(), Some(3));
+        queue.enque(4);
+        assert_eq!(queue.deque(), Some(4));
+        queue.enque(5);
+        assert_eq!(queue.deque(), Some(5));
+        queue.enque(6);
+        assert_eq!(queue.deque(), Some(6));
+        queue.enque(7);
+        assert_eq!(queue.deque(), Some(7));
+    }
+}

--- a/src/gat/tumbling_operator/queue/mod.rs
+++ b/src/gat/tumbling_operator/queue/mod.rs
@@ -79,12 +79,7 @@ where
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
-}
 
-impl<T> TumblingQueue<T>
-where
-    T: Queue,
-{
     /// Enque an item and deque the oldest item if overflow.
     pub fn enque_and_deque_overflow(&mut self, item: T::Item) -> Option<T::Item> {
         if self.0.is_full() {

--- a/src/gat/tumbling_operator/queue/mod.rs
+++ b/src/gat/tumbling_operator/queue/mod.rs
@@ -1,0 +1,99 @@
+/// Queue.
+pub trait Queue {
+    /// Item.
+    type Item;
+
+    /// Create a new queue with the given capacity.
+    fn with_capacity(cap: usize) -> Self;
+
+    /// Enque.
+    fn enque(&mut self, item: Self::Item);
+
+    /// Deque.
+    fn deque(&mut self) -> Option<Self::Item>;
+
+    /// Length.
+    fn len(&self) -> usize;
+
+    /// Capacity.
+    fn cap(&self) -> usize;
+
+    /// Get a reference of the item in the given position (tail position is `0`).
+    fn get(&self, idx: usize) -> Option<&Self::Item>;
+
+    /// Get a mutable reference of the item in the given position (tail position is `0`).
+    fn get_mut(&mut self, idx: usize) -> Option<&mut Self::Item>;
+
+    /// Is empty.
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Is full.
+    #[inline]
+    fn is_full(&self) -> bool {
+        self.len() == self.cap()
+    }
+
+    /// Returns whether elements are on stack.
+    fn is_inline(&self) -> bool;
+}
+
+/// The core tumbling queue.
+#[derive(Debug, Clone)]
+pub struct TumblingQueue<T>(T);
+
+impl<T> TumblingQueue<T>
+where
+    T: Queue,
+{
+    /// Latest.
+    #[inline]
+    pub fn latest(&self) -> &T::Item {
+        // According to the dynmaic tumbling algorithm,
+        // it must contain at least one item.
+        self.0.get(0).unwrap()
+    }
+
+    /// Get the latest `n` item.
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<&T::Item> {
+        self.0.get(idx)
+    }
+
+    /// Return whether the elements are on the stack.
+    #[inline]
+    pub fn is_inline(&self) -> bool {
+        self.0.is_inline()
+    }
+
+    /// Get current length.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<T> TumblingQueue<T>
+where
+    T: Queue,
+{
+    /// Enque an item and deque the oldest item if overflow.
+    pub fn enque_and_deque_overflow(&mut self, item: T::Item) -> Option<T::Item> {
+        if self.0.is_full() {
+            let oldest = self.0.deque();
+            self.0.enque(item);
+            oldest
+        } else {
+            self.0.enque(item);
+            None
+        }
+    }
+}

--- a/src/gat/tumbling_operator/queue/mod.rs
+++ b/src/gat/tumbling_operator/queue/mod.rs
@@ -1,3 +1,5 @@
+use core::ops::Deref;
+
 /// Circular Queue.
 pub mod circular;
 
@@ -51,38 +53,6 @@ impl<T> TumblingQueue<T>
 where
     T: Queue,
 {
-    /// Latest.
-    #[inline]
-    pub fn latest(&self) -> &T::Item {
-        // According to the dynmaic tumbling algorithm,
-        // it must contain at least one item.
-        self.0.get(0).unwrap()
-    }
-
-    /// Get the latest `n` item.
-    #[inline]
-    pub fn get(&self, idx: usize) -> Option<&T::Item> {
-        self.0.get(idx)
-    }
-
-    /// Return whether the elements are on the stack.
-    #[inline]
-    pub fn is_inline(&self) -> bool {
-        self.0.is_inline()
-    }
-
-    /// Get current length.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Is empty.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     /// Enque an item and deque the oldest item if overflow.
     pub fn enque_and_deque_overflow(&mut self, item: T::Item) -> Option<T::Item> {
         if self.0.is_full() {
@@ -93,5 +63,16 @@ where
             self.0.enque(item);
             None
         }
+    }
+}
+
+impl<T> Deref for TumblingQueue<T>
+where
+    T: Queue,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/gat/tumbling_operator/queue/mod.rs
+++ b/src/gat/tumbling_operator/queue/mod.rs
@@ -1,3 +1,6 @@
+/// Circular Queue.
+pub mod circular;
+
 /// Queue.
 pub trait Queue {
     /// Item.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,10 @@ pub mod rayon;
 #[cfg(feature = "async")]
 pub mod async_operator;
 
+/// Operator using GAT.
+#[cfg(feature = "gat")]
+pub mod gat;
+
 pub use iter::IndicatorIteratorExt;
 pub use operator::{facet, map, Operator, OperatorExt};
 pub use ticked::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub mod gat;
 
 /// Prelude.
 pub mod prelude {
+    pub use crate::operator::{BoxOperator, LocalBoxOperator, Operator, OperatorExt};
     pub use crate::window::{Period, Tick, TickValue, TumblingWindow};
 
     #[cfg(feature = "gat")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,14 @@ pub mod async_operator;
 #[cfg(feature = "gat")]
 pub mod gat;
 
+/// Prelude.
+pub mod prelude {
+    pub use crate::window::{Period, Tick, TickValue, TumblingWindow};
+
+    #[cfg(feature = "gat")]
+    pub use crate::gat::*;
+}
+
 pub use iter::IndicatorIteratorExt;
 pub use operator::{facet, map, Operator, OperatorExt};
 pub use ticked::{

--- a/src/window/tick.rs
+++ b/src/window/tick.rs
@@ -3,6 +3,8 @@ use core::cmp::{Ord, Ordering, PartialOrd};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
+use crate::TickValue;
+
 #[cfg(not(feature = "serde-derive"))]
 /// A tick in time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,6 +27,11 @@ impl Tick {
     /// Get the timestamp.
     pub fn ts(&self) -> Option<&OffsetDateTime> {
         self.0.as_ref()
+    }
+
+    /// With value.
+    pub fn with_value<T>(self, value: T) -> TickValue<T> {
+        TickValue { tick: self, value }
     }
 }
 

--- a/src/window/tick_value.rs
+++ b/src/window/tick_value.rs
@@ -56,3 +56,16 @@ impl<T> Tickable for TickValue<T> {
         self
     }
 }
+
+impl<T> core::fmt::Display for TickValue<T>
+where
+    T: core::fmt::Display,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if let Some(ts) = self.tick.ts() {
+            write!(f, "({ts}, {})", self.value)
+        } else {
+            write!(f, "(*, {})", self.value)
+        }
+    }
+}

--- a/src/window/tick_value.rs
+++ b/src/window/tick_value.rs
@@ -28,6 +28,17 @@ impl<T> TickValue<T> {
             value,
         }
     }
+
+    /// Map over the tick value.
+    pub fn map<U, F>(self, f: F) -> TickValue<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        TickValue {
+            tick: self.tick,
+            value: (f)(self.value),
+        }
+    }
 }
 
 impl<T> Tickable for TickValue<T> {


### PR DESCRIPTION
Using the recently stabilized GAT feature, we introduced a new way to define tumbling operators with a new basic trait `GatOperator`.