### PR TITLE
context: delay the data updating in `insert_data`

### DIFF
--- a/examples/context/data.rs
+++ b/examples/context/data.rs
@@ -44,10 +44,12 @@ fn main() -> anyhow::Result<()> {
             if let Some(data) = context.data().get::<&str>() {
                 println!("data: {}", data);
             }
-            let count = context.data().get::<Count>().unwrap();
-            println!("odds count: {}", count.0);
-            let count = context.data().get::<EvenCount>().unwrap();
-            println!("even count: {}", count.0);
+            if let Some(count) = context.data().get::<Count>() {
+                println!("previous odds count: {}", count.0);
+            }
+            if let Some(count) = context.data().get::<EvenCount>() {
+                println!("previous even count: {}", count.0);
+            }
         })
         .from_context::<&str>() // Asserting that the context has a `&str` data.
         .provide("This is my data!")

--- a/examples/context/data.rs
+++ b/examples/context/data.rs
@@ -55,6 +55,9 @@ fn main() -> anyhow::Result<()> {
         .provide("This is my data!")
         .insert_data(odds_counter)
         .insert(even_signal::<bool, EvenCount>)
+        // // Note that if we add an identical operator here, the result should still be correct.
+        // // Since the data updating is happended after the inner operator is applied.
+        // .insert(even_signal::<bool, EvenCount>)
         .cache(1)
         .finish();
     let data = [1, 2, 3];


### PR DESCRIPTION
### Delay data updating in `insert_data` and `insert`
We should calculate the next data first but insert it after the inner operator is applied. For the operator is always assuming that the same data extracted from the input should be the same during the whole evaluation. 

If we were to insert the data immediately, with two identical date-updating operators in the layers, the later operator may produce a different data value since the input data may have been updated by the previous one.