### PR TITLE
Context: Add optional layer

### DIFF
--- a/crates/indicator/src/context/layer/mod.rs
+++ b/crates/indicator/src/context/layer/mod.rs
@@ -107,6 +107,19 @@ where
         self.with(Insert(f))
     }
 
+    /// Optionally add the [`Insert`] layer with the given [`RefOperator`] constructor.
+    ///
+    /// See [`insert_env`] for more details.
+    fn insert_env_if<R, Out, F>(self, enable: bool, f: F) -> Stack<Self, OptionalLayer<Insert<F>>>
+    where
+        F: Fn() -> R,
+        R: for<'a> RefOperator<'a, In, Output = Out>,
+        Out: Send + Sync + 'static,
+        Self: Sized,
+    {
+        self.with_if(if enable { Some(Insert(f)) } else { None })
+    }
+
     /// Add a [`InsertData`] layer with the given [`RefOperator`] constructor.
     /// (i.e. a function that returns a [`RefOperator`]).
     ///
@@ -119,6 +132,23 @@ where
         Self: Sized,
     {
         self.with(InsertData(f))
+    }
+
+    /// Optionally add the [`InsertData`] layer with the given [`RefOperator`] constructor.
+    ///
+    /// See [`insert_data`] for more details.
+    fn insert_data_if<R, Out, F>(
+        self,
+        enable: bool,
+        f: F,
+    ) -> Stack<Self, OptionalLayer<InsertData<F>>>
+    where
+        F: Fn() -> R,
+        R: for<'a> RefOperator<'a, In, Output = Option<Out>>,
+        Out: Send + Sync + 'static,
+        Self: Sized,
+    {
+        self.with_if(if enable { Some(InsertData(f)) } else { None })
     }
 
     /// Add a [`InsertWithData`] layer with the given [`RefOperator`] constructor.
@@ -134,6 +164,28 @@ where
         Self: Sized,
     {
         self.with(InsertWithData(f))
+    }
+
+    /// Optionally add the [`InsertWithData`] layer with the given [`RefOperator`] constructor.
+    ///
+    /// See [`insert`] for more details.
+    fn insert_if<R, Env, Data, F>(
+        self,
+        enable: bool,
+        f: F,
+    ) -> Stack<Self, OptionalLayer<InsertWithData<F>>>
+    where
+        F: Fn() -> R,
+        R: for<'a> RefOperator<'a, In, Output = (Env, Option<Data>)>,
+        Env: Send + Sync + 'static,
+        Data: Send + Sync + 'static,
+        Self: Sized,
+    {
+        self.with_if(if enable {
+            Some(InsertWithData(f))
+        } else {
+            None
+        })
     }
 
     /// Add an inspect layer with the given closure.

--- a/crates/indicator/src/context/layer/mod.rs
+++ b/crates/indicator/src/context/layer/mod.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use self::{stack::Stack, then::Then};
+use self::{optional::OptionalLayer, stack::Stack, then::Then};
 
 use super::{
     AddData, BoxContextOperator, Context, ContextOperator, ContextOperatorExt, Insert, InsertData,
@@ -25,6 +25,9 @@ pub mod stack;
 
 /// Then layer.
 pub mod then;
+
+/// Optional layer.
+pub mod optional;
 
 /// Layer.
 /// Convert an [`ContextOperator`] to another [`ContextOperator`]
@@ -180,6 +183,16 @@ where
         Self: Sized,
     {
         self.with(Then(builder))
+    }
+
+    /// Optionally add a layer.
+    fn with_if<L>(self, layer: Option<L>) -> Stack<Self, OptionalLayer<L>>
+    where
+        L: Layer<In, Self::Operator>,
+        L::Operator: ContextOperator<In, Out = Self::Out>,
+        Self: Sized,
+    {
+        self.with(OptionalLayer(layer))
     }
 }
 

--- a/crates/indicator/src/context/layer/optional.rs
+++ b/crates/indicator/src/context/layer/optional.rs
@@ -1,0 +1,53 @@
+use crate::{
+    context::{ContextOperator, Value},
+    Operator,
+};
+
+use super::Layer;
+
+/// Optional layer.
+/// It requires that the inner layer won't change the input and output of the input operator.
+#[derive(Debug, Clone, Copy)]
+pub struct OptionalLayer<L>(pub(crate) Option<L>);
+
+impl<In, P, L> Layer<In, P> for OptionalLayer<L>
+where
+    P: ContextOperator<In>,
+    L: Layer<In, P>,
+    L::Operator: ContextOperator<In, Out = P::Out>,
+{
+    type Operator = Either<L::Operator, P>;
+
+    type Out = P::Out;
+
+    fn layer(&self, operator: P) -> Self::Operator {
+        match &self.0 {
+            Some(l) => Either::Left(l.layer(operator)),
+            None => Either::Right(operator),
+        }
+    }
+}
+
+/// Either operator.
+#[derive(Debug, Clone, Copy)]
+pub enum Either<A, B> {
+    /// Left.
+    Left(A),
+    /// Right.
+    Right(B),
+}
+
+impl<In, Out, A, B> Operator<Value<In>> for Either<A, B>
+where
+    A: ContextOperator<In, Out = Out>,
+    B: ContextOperator<In, Out = Out>,
+{
+    type Output = Value<Out>;
+
+    fn next(&mut self, input: Value<In>) -> Self::Output {
+        match self {
+            Either::Left(a) => a.next(input),
+            Either::Right(b) => b.next(input),
+        }
+    }
+}

--- a/crates/indicator/src/context/mod.rs
+++ b/crates/indicator/src/context/mod.rs
@@ -22,6 +22,7 @@ use self::{
         data::AddDataOperator,
         insert::{InsertDataOperator, InsertOperator, InsertWithDataOperator},
         inspect::InspectOperator,
+        optional::Either,
         then::ThenOperator,
     },
 };
@@ -35,6 +36,7 @@ pub use self::{
         insert::{Insert, InsertData, InsertWithData},
         inspect::Inspect,
         layer_fn,
+        optional::OptionalLayer,
         then::Then,
         BoxLayer, Layer,
     },
@@ -211,6 +213,16 @@ pub trait ContextOperatorExt<In>: ContextOperator<In> {
         Self: Sized,
     {
         self.with(Then(builder))
+    }
+
+    /// Optionally add a layer.
+    fn with_if<L>(self, layer: Option<L>) -> Either<L::Operator, Self>
+    where
+        L: Layer<In, Self>,
+        L::Operator: ContextOperator<In, Out = Self::Out>,
+        Self: Sized,
+    {
+        self.with(OptionalLayer(layer))
     }
 }
 

--- a/crates/indicator/src/context/mod.rs
+++ b/crates/indicator/src/context/mod.rs
@@ -139,6 +139,22 @@ pub trait ContextOperatorExt<In>: ContextOperator<In> {
         self.with(Insert(f))
     }
 
+    /// Optionally add a [`Insert`] layer with the given [`RefOperator`] constructor.
+    ///
+    /// See [`insert_env`] for more details.
+    fn insert_env_if<R, Out>(
+        self,
+        enable: bool,
+        f: impl Fn() -> R,
+    ) -> Either<InsertOperator<Self, R>, Self>
+    where
+        R: for<'a> RefOperator<'a, In, Output = Out>,
+        Out: Send + Sync + 'static,
+        Self: Sized,
+    {
+        self.with_if(if enable { Some(Insert(f)) } else { None })
+    }
+
     /// Add a [`InsertData`] layer with the given [`RefOperator`] constructor.
     /// (i.e. a function that returns a [`RefOperator`]).
     ///
@@ -150,6 +166,22 @@ pub trait ContextOperatorExt<In>: ContextOperator<In> {
         Self: Sized,
     {
         self.with(InsertData(f))
+    }
+
+    /// Optionally add a [`InsertData`] layer with the given [`RefOperator`] constructor.
+    ///
+    /// See [`insert_data`] for more details.
+    fn insert_data_if<R, Out>(
+        self,
+        enable: bool,
+        f: impl Fn() -> R,
+    ) -> Either<InsertDataOperator<Self, R>, Self>
+    where
+        R: for<'a> RefOperator<'a, In, Output = Option<Out>>,
+        Out: Send + Sync + 'static,
+        Self: Sized,
+    {
+        self.with_if(if enable { Some(InsertData(f)) } else { None })
     }
 
     /// Add a [`InsertWithData`] layer with the given [`RefOperator`] constructor.
@@ -164,6 +196,27 @@ pub trait ContextOperatorExt<In>: ContextOperator<In> {
         Self: Sized,
     {
         self.with(InsertWithData(f))
+    }
+
+    /// Optionally add a [`InsertWithData`] layer with the given [`RefOperator`] constructor.
+    ///
+    /// See [`insert`] for more details.
+    fn insert_if<R, Env, Data>(
+        self,
+        enable: bool,
+        f: impl Fn() -> R,
+    ) -> Either<InsertWithDataOperator<Self, R>, Self>
+    where
+        R: for<'a> RefOperator<'a, In, Output = (Env, Option<Data>)>,
+        Env: Send + Sync + 'static,
+        Data: Send + Sync + 'static,
+        Self: Sized,
+    {
+        self.with_if(if enable {
+            Some(InsertWithData(f))
+        } else {
+            None
+        })
     }
 
     /// Add an inspect layer with the given closure.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -47,3 +47,8 @@ required-features = ["context"]
 name = "stack_sugar"
 path = "context/stack_sugar.rs"
 required-features = ["context"]
+
+[[example]]
+name = "optional"
+path = "context/optional.rs"
+required-features = ["context"]

--- a/examples/context/optional.rs
+++ b/examples/context/optional.rs
@@ -1,0 +1,63 @@
+use indicator::{prelude::*, IndicatorIteratorExt};
+use num::Num;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+struct AddTwo<T>(T);
+
+/// An operator that just add two to the input.
+#[operator(input = T)]
+fn add_two<T>(In(value): In<&T>) -> AddTwo<T>
+where
+    T: Num + Clone,
+    T: Send + Sync + 'static,
+{
+    let two = T::one() + T::one();
+    AddTwo(value.clone() + two)
+}
+
+// Derive `Clone` to satisfy the requirement of `output_with`.
+#[derive(Clone)]
+struct Ma<T>(T);
+
+/// An operator that does the following:
+/// `x => (x + prev(x)) / 2`
+#[operator(input = T)]
+fn ma<T>(In(input): In<&T>, Env(x): Env<Option<&AddTwo<T>>>, Prev(prev): Prev<&Ma<T>>) -> Ma<T>
+where
+    T: Num + Clone,
+    T: Send + Sync + 'static,
+{
+    let two = T::one() + T::one();
+    let prev = prev.map(|v| v.0.clone()).unwrap_or(T::zero());
+    let x = x.map(|v| v.0.clone()).unwrap_or_else(|| input.clone());
+    Ma((x + prev) / two)
+}
+
+fn main() -> anyhow::Result<()> {
+    let enable_add_two = std::env::var("ENABLE_ADD_TWO").is_ok();
+    let op = insert_env_and_output(ma)
+        .inspect(|value, context| {
+            println!("input: {}", value);
+            if let Some(AddTwo(x)) = context.env().get::<AddTwo<Decimal>>() {
+                println!("AddTwo: {x}");
+            }
+        })
+        .insert_env_if(enable_add_two, add_two)
+        .cache(1)
+        .finish();
+    let data = [dec!(1), dec!(2), dec!(3)];
+
+    let ans = data
+        .into_iter()
+        .indicator(op)
+        .map(|Ma(x)| x)
+        .collect::<Vec<_>>();
+
+    if enable_add_two {
+        assert_eq!(ans, [dec!(1.5), dec!(2.75), dec!(3.875)]);
+    } else {
+        assert_eq!(ans, [dec!(0.5), dec!(1.25), dec!(2.125)]);
+    }
+    Ok(())
+}


### PR DESCRIPTION
- Add `OptionalLayer` for optionally adding a layer to the context operator.
- Also add `with_if` helper methods for it.
- Based on `with_if`, `insert_env_if`, `insert_data_if` and `insert_if` are also provided.